### PR TITLE
Add brand assignment UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import Calendar from "./components/calendar/Calendar.jsx";
 import BlogManagement from "./pages/BlogManagement.jsx";
 import AgentAIDashboard from "./components/ai/AgentDashboard.jsx";
 import UserManagement from "./components/admin/UserManagement.jsx";
+import ClientsPage from "./pages/ClientsPage.jsx";
 import ProfileSetup from "./pages/ProfileSetup.jsx";
 import Profile from "./pages/Profile.jsx";
 import ProfileSettings from "./pages/ProfileSettings.jsx";
@@ -119,6 +120,16 @@ const App = () => {
               <ProtectedRoute>
                 <DashboardLayout>
                   <Reminders />
+                </DashboardLayout>
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: '/dashboard/clients',
+            element: (
+              <ProtectedRoute requiredRole="admin">
+                <DashboardLayout>
+                  <ClientsPage />
                 </DashboardLayout>
               </ProtectedRoute>
             ),

--- a/src/components/common/Sidebar.jsx
+++ b/src/components/common/Sidebar.jsx
@@ -33,6 +33,7 @@ const Sidebar = () => {
     { to: "/dashboard/blog", icon: <HiOutlineNewspaper />, label: "Blog", roles: ["admin", "client", "superadmin"] },
     { to: "/dashboard/agent", icon: <HiOutlineSparkles />, label: "AI Agent", roles: ["admin", "superadmin"] },
     { to: "/dashboard/reminders", icon: <HiOutlineBell />, label: "Reminders", roles: ["admin", "client", "superadmin"] },
+    { to: "/dashboard/clients", icon: <HiOutlineUsers />, label: "Brands", roles: ["admin", "superadmin"] },
     { to: "/dashboard/users", icon: <HiOutlineUsers />, label: "Users", roles: ["superadmin"] },
   ];
 

--- a/src/data/roles.json
+++ b/src/data/roles.json
@@ -6,7 +6,8 @@
         { "id": "calendar", "label": "Calendar", "desc": "Plan and view project schedules." },
         { "id": "blog", "label": "Blog Management", "desc": "Post, edit, and manage blogs." },
         { "id": "agent", "label": "AI Agent", "desc": "Generate marketing drafts." },
-        { "id": "users", "label": "User Management", "desc": "Manage user accounts & roles." }
+        { "id": "users", "label": "User Management", "desc": "Manage user accounts & roles." },
+        { "id": "brands", "label": "Brand Management", "desc": "Manage client brands." }
       ]
     },
     "admin": {
@@ -14,7 +15,8 @@
         { "id": "kanban", "label": "Kanban Board", "desc": "Task management with drag & drop." },
         { "id": "calendar", "label": "Calendar", "desc": "Plan and view project schedules." },
         { "id": "blog", "label": "Blog Management", "desc": "Post, edit, and manage blogs." },
-        { "id": "agent", "label": "AI Agent", "desc": "Generate marketing drafts." }
+        { "id": "agent", "label": "AI Agent", "desc": "Generate marketing drafts." },
+        { "id": "brands", "label": "Brand Management", "desc": "Manage client brands." }
       ]
     },
     "client": {

--- a/src/pages/__tests__/ClientsPage.test.jsx
+++ b/src/pages/__tests__/ClientsPage.test.jsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import ClientsPage from '../ClientsPage.jsx';
+import { UserProfileContext } from '../../context/UserProfileContext';
+
+jest.mock('../../supabaseClient', () => ({
+  supabase: {
+    from: jest.fn(() => ({
+      select: jest.fn().mockReturnThis(),
+      order: jest.fn().mockResolvedValue({ data: [], error: null }),
+      eq: jest.fn().mockResolvedValue({ data: [], error: null }),
+      insert: jest.fn().mockResolvedValue({ error: null }),
+      delete: jest.fn(() => ({ eq: jest.fn().mockResolvedValue({ error: null }) })),
+    })),
+  },
+}));
+
+const renderWithProfile = (ui, profile) =>
+  render(
+    <UserProfileContext.Provider value={{ profile }}>
+      {ui}
+    </UserProfileContext.Provider>
+  );
+
+describe('ClientsPage', () => {
+  test('shows manage button for admins', async () => {
+    renderWithProfile(<ClientsPage />, { role: 'admin' });
+    expect(await screen.findByText(/Clients/)).toBeInTheDocument();
+    expect(screen.getByText(/Add Brand/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- enable brand management via sidebar
- allow admin routes to show client brands page
- expose brand management module in role metadata
- add user assignment modal to Clients page
- test minimal ClientsPage render

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run lint --silent` *(fails: ESLint plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ed9dc174c8333a1077f92334dc50f