### PR TITLE
Add deploy script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,3 +176,13 @@ psql < supabase/create_reminders_table.sql
 
 A GitHub Actions workflow installs dependencies, lints the codebase and runs tests on every push and pull request.
 
+### Deployment
+
+After configuring `.env` and setting up the Supabase database, build the production bundle and serve it locally:
+
+```bash
+npm run deploy
+```
+
+The command runs `npm run build` and launches a lightweight server using `serve`. The dashboard will be available on `http://localhost:3000` by default. You can also run `npm run electron` to start the desktop app against the same build.
+

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "eject": "react-scripts eject",
     "electron": "concurrently \"npm start\" \"electron desktop\"",
     "mobile": "cd mobile && npx react-native start",
-    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint . --ext .js,.jsx"
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint . --ext .js,.jsx",
+    "deploy": "npm run build && npx serve -s build"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.49.8",


### PR DESCRIPTION
## Summary
- add a `deploy` script in `package.json` for serving the production build
- document deployment process in README

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee0c24d6483339db5ddcab97f9d17