### PR TITLE
Fix lint warning and prevent duplicate Supabase clients

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -16,7 +16,6 @@ import KanbanWidget from "../components/widgets/KanbanWidget.js";
 
 const Dashboard = () => {
   const { profile } = useContext(UserProfileContext);
-  const { user } = useContext(AuthContext);
   const { isOpen } = useContext(SidebarContext);
 
   const firstName = profile?.name?.split(" ")[0] || "User";

--- a/src/utils/supabase.js
+++ b/src/utils/supabase.js
@@ -1,17 +1,6 @@
 // src/utils/supabase.js
-import { createClient } from '@supabase/supabase-js';
-
-const supabaseUrl = process.env.REACT_APP_SUPABASE_URL;
-const supabaseAnonKey = process.env.REACT_APP_SUPABASE_ANON_KEY;
-
-if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error(
-    'Supabase config missing! Check your .env: REACT_APP_SUPABASE_URL and REACT_APP_SUPABASE_ANON_KEY are required.',
-  );
-}
-
-const supabase = createClient(supabaseUrl, supabaseAnonKey, {
-  auth: { persistSession: true },
-});
+// Re-export the single Supabase client instance to avoid multiple
+// GoTrueClient warnings when the app is loaded in the browser.
+import { supabase } from '../supabaseClient';
 
 export default supabase;


### PR DESCRIPTION
## Summary
- remove unused `user` variable from `Dashboard` page
- reuse the single Supabase client to avoid the `Multiple GoTrueClient instances` warning

## Testing
- `npm run lint` *(fails: ESLint plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ee91700c48333ba5362d671883956