### PR TITLE
Fix unused import error in dashboard

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,6 +1,5 @@
 import React, { useContext } from "react";
 import { UserProfileContext } from "../context/UserProfileContext";
-import { AuthContext } from "../context/AuthContext";
 import { SidebarContext } from "../context/SidebarContext";
 import { motion } from "framer-motion";
 import {


### PR DESCRIPTION
## Summary
- remove unused `AuthContext` import from Dashboard page to clear ESLint warning

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eeb35d7948333b108154aad5eacaa