### PR TITLE
Fix auth profile tables and add custom cursor

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -137,7 +137,7 @@ const App = () => {
           {
             path: '/dashboard/users',
             element: (
-              <ProtectedRoute requiredRole="superadmin">
+              <ProtectedRoute requiredRole="super_admin">
                 <DashboardLayout>
                   <UserManagement />
                 </DashboardLayout>

--- a/src/components/admin/UserManagement.jsx
+++ b/src/components/admin/UserManagement.jsx
@@ -3,19 +3,19 @@ import PropTypes from "prop-types"; // eslint-disable-line no-unused-vars
 import { supabase } from "../../supabaseClient";
 import { motion } from "framer-motion";
 
-const roles = ["superadmin", "admin", "client"];
+const roles = ["super_admin", "admin", "member", "user"];
 
 const UserManagement = () => {
   const [users, setUsers] = useState([]);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [role, setRole] = useState("client");
+  const [role, setRole] = useState("user");
   const [errorMsg, setErrorMsg] = useState("");
 
   const fetchUsers = async () => {
     const { data, error } = await supabase
-      .from("profiles")
-      .select("id, email, name, tier")
+      .from("user_profiles")
+      .select("id, email, full_name, role")
       .order("created_at", { ascending: false });
     if (error) {
       console.error("Fetch users error", error);
@@ -45,10 +45,11 @@ const UserManagement = () => {
     }
 
     const { user } = data;
-    const { error: insertError } = await supabase.from("profiles").insert({
+    const { error: insertError } = await supabase.from("user_profiles").insert({
       id: user.id,
       email: user.email,
-      tier: role,
+      role,
+      full_name: '',
     });
     if (insertError) {
       console.error("Profile insert error", insertError);
@@ -58,15 +59,15 @@ const UserManagement = () => {
 
     setEmail("");
     setPassword("");
-    setRole("client");
+    setRole("user");
     setErrorMsg("");
     fetchUsers();
   };
 
   const updateRole = async (id, newRole) => {
     const { error: updateError } = await supabase
-      .from("profiles")
-      .update({ tier: newRole })
+      .from("user_profiles")
+      .update({ role: newRole })
       .eq("id", id);
     if (updateError) {
       console.error("Update role error", updateError);
@@ -152,10 +153,10 @@ const UserManagement = () => {
             {users.map((u) => (
               <tr key={u.id} className="border-b border-white/5">
                 <td className="p-3">{u.email}</td>
-                <td className="p-3">{u.name || "-"}</td>
+                <td className="p-3">{u.full_name || "-"}</td>
                 <td className="p-3">
                   <select
-                    value={u.tier}
+                    value={u.role}
                     onChange={(e) => updateRole(u.id, e.target.value)}
                     className="bg-black border border-white/10 rounded-md p-1"
                   >

--- a/src/components/auth/LoginForm.jsx
+++ b/src/components/auth/LoginForm.jsx
@@ -10,7 +10,6 @@ import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { supabase } from '../../supabaseClient';
 const logo = '/fedrix.svg';
-import { AuthContext } from '../../context/AuthContext';
 import { UserProfileContext } from '../../context/UserProfileContext';
 
 const LoginForm = () => {
@@ -21,7 +20,6 @@ const LoginForm = () => {
   const [slidIn, setSlidIn] = useState(false);
   const [error, setError] = useState('');
   const navigate = useNavigate();
-  const { login } = useContext(AuthContext);
   const { saveProfile } = useContext(UserProfileContext);
 
   const handleLogin = useCallback(async () => {
@@ -38,17 +36,9 @@ const LoginForm = () => {
     }
 
     const { user } = data;
-    const metadata = user.user_metadata || {};
-    let role = metadata.role || 'client';
-
-    if (user.email === 'sajal@fedrixgroup.com') {
-      role = 'superadmin';
-    }
-
-    login(role, user.email);
 
     const { data: profile } = await supabase
-      .from('profiles')
+      .from('user_profiles')
       .select('*')
       .eq('id', user.id)
       .single();
@@ -58,7 +48,7 @@ const LoginForm = () => {
     }
 
     navigate('/dashboard');
-  }, [email, password, login, navigate, saveProfile]);
+  }, [email, password, navigate, saveProfile]);
 
   useEffect(() => {
     const knob = knobRef.current;

--- a/src/components/auth/ProtectedRoute.js
+++ b/src/components/auth/ProtectedRoute.js
@@ -1,18 +1,18 @@
 // src/components/auth/ProtectedRoute.js
 
-import React, { useContext } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import { Navigate } from "react-router-dom";
-import { AuthContext } from "../../context/AuthContext";
+import { useAuth } from "../../context/AuthContext";
 
 const ProtectedRoute = ({ children, requiredRole }) => {
-  const { user } = useContext(AuthContext);
-  if (!user) return <Navigate to="/login" replace />;
+  const { currentUser } = useAuth();
+  if (!currentUser) return <Navigate to="/login" replace />;
 
   if (
     requiredRole &&
-    user.role !== requiredRole &&
-    !(user.role === "superadmin" && requiredRole === "admin")
+    currentUser.role !== requiredRole &&
+    !(currentUser.role === "super_admin" && requiredRole === "admin")
   ) {
     return <Navigate to="/unauthorized" replace />;
   }

--- a/src/components/calendar/Calendar.jsx
+++ b/src/components/calendar/Calendar.jsx
@@ -20,7 +20,7 @@ const Calendar = () => {
     const { data } = await supabase.from("events").select("*").order("start", { ascending: true });
 
     const filtered =
-      profile?.tier === "admin"
+      profile?.role === "admin"
         ? data
         : data.filter((e) => e.created_by === profile?.id);
 
@@ -31,7 +31,7 @@ const Calendar = () => {
     }));
 
     setEvents(mapped);
-  }, [profile?.id, profile?.tier]);
+  }, [profile?.id, profile?.role]);
 
   useEffect(() => {
     if (!profile?.id) return;

--- a/src/components/calendar/SocialMediaCalendar.js
+++ b/src/components/calendar/SocialMediaCalendar.js
@@ -28,14 +28,14 @@ const SocialMediaCalendar = () => {
       if (error) throw error;
 
       const visible =
-        profile?.tier === "admin" ? data : data.filter((p) => p.created_by === profile?.id);
+        profile?.role === "admin" ? data : data.filter((p) => p.created_by === profile?.id);
       setPosts(visible);
       setErrorMsg("");
     } catch (err) {
       console.error("Fetch posts error", err);
       setErrorMsg(err.message || "Failed to fetch posts");
     }
-  }, [profile?.id, profile?.tier]);
+  }, [profile?.id, profile?.role]);
 
   useEffect(() => {
     if (!user?.email) return;

--- a/src/components/calendar/__tests__/Calendar.test.jsx
+++ b/src/components/calendar/__tests__/Calendar.test.jsx
@@ -51,7 +51,7 @@ beforeEach(() => {
 
 test('renders events and filters by type', async () => {
   render(
-    <UserProfileContext.Provider value={{ profile: { id: '1', tier: 'admin' } }}>
+    <UserProfileContext.Provider value={{ profile: { id: '1', role: 'admin' } }}>
       <Calendar />
     </UserProfileContext.Provider>
   );
@@ -66,7 +66,7 @@ test('renders events and filters by type', async () => {
 
 test('opens modal when event clicked', async () => {
   render(
-    <UserProfileContext.Provider value={{ profile: { id: '1', tier: 'admin' } }}>
+    <UserProfileContext.Provider value={{ profile: { id: '1', role: 'admin' } }}>
       <Calendar />
     </UserProfileContext.Provider>
   );

--- a/src/components/calendar/__tests__/SocialMediaCalendar.test.jsx
+++ b/src/components/calendar/__tests__/SocialMediaCalendar.test.jsx
@@ -42,7 +42,7 @@ beforeEach(() => {
 function renderCalendar(ctx = {}) {
   return render(
     <AuthContext.Provider value={{ user: { email: 'a' } }}>
-      <UserProfileContext.Provider value={{ profile: { id: '1', tier: 'admin' } }}>
+      <UserProfileContext.Provider value={{ profile: { id: '1', role: 'admin' } }}>
         <AgentAIContext.Provider value={{ generateContent: ctx.generateContent || jest.fn().mockResolvedValue('Generated'), loading: false }}>
           <SocialMediaCalendar />
         </AgentAIContext.Provider>

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -9,7 +9,7 @@ const Header = () => {
   const { profile } = useContext(UserProfileContext);
 
   const { toggleSidebar } = useContext(SidebarContext);
-  const tier = profile?.tier || "guest";
+  const tier = profile?.role || "guest";
 
   return (
     <motion.header

--- a/src/components/common/Sidebar.jsx
+++ b/src/components/common/Sidebar.jsx
@@ -18,7 +18,7 @@ const Sidebar = () => {
   const { logoutProfile, profile } = useContext(UserProfileContext);
   const { isOpen } = useContext(SidebarContext);
   const navigate = useNavigate();
-  const tier = profile?.tier || user?.role || "client";
+  const role = profile?.role || user?.role || "user";
 
   const handleLogout = () => {
     logout();
@@ -28,13 +28,13 @@ const Sidebar = () => {
 
   const navItems = [
     { to: "/dashboard", icon: <HiViewBoards />, label: "Dashboard" },
-    { to: "/dashboard/kanban", icon: <HiViewBoards />, label: "Kanban", roles: ["admin", "client", "superadmin"] },
-    { to: "/dashboard/calendar", icon: <HiOutlineCalendar />, label: "Calendar", roles: ["admin", "superadmin"] },
-    { to: "/dashboard/blog", icon: <HiOutlineNewspaper />, label: "Blog", roles: ["admin", "client", "superadmin"] },
-    { to: "/dashboard/agent", icon: <HiOutlineSparkles />, label: "AI Agent", roles: ["admin", "superadmin"] },
-    { to: "/dashboard/reminders", icon: <HiOutlineBell />, label: "Reminders", roles: ["admin", "client", "superadmin"] },
-    { to: "/dashboard/clients", icon: <HiOutlineUsers />, label: "Brands", roles: ["admin", "superadmin"] },
-    { to: "/dashboard/users", icon: <HiOutlineUsers />, label: "Users", roles: ["superadmin"] },
+    { to: "/dashboard/kanban", icon: <HiViewBoards />, label: "Kanban", roles: ["admin", "member", "super_admin"] },
+    { to: "/dashboard/calendar", icon: <HiOutlineCalendar />, label: "Calendar", roles: ["admin", "super_admin"] },
+    { to: "/dashboard/blog", icon: <HiOutlineNewspaper />, label: "Blog", roles: ["admin", "member", "super_admin"] },
+    { to: "/dashboard/agent", icon: <HiOutlineSparkles />, label: "AI Agent", roles: ["admin", "super_admin"] },
+    { to: "/dashboard/reminders", icon: <HiOutlineBell />, label: "Reminders", roles: ["admin", "member", "super_admin"] },
+    { to: "/dashboard/clients", icon: <HiOutlineUsers />, label: "Brands", roles: ["admin", "super_admin"] },
+    { to: "/dashboard/users", icon: <HiOutlineUsers />, label: "Users", roles: ["super_admin"] },
   ];
 
   return (
@@ -50,7 +50,7 @@ const Sidebar = () => {
 
       <nav className="flex flex-col space-y-4">
         {navItems
-          .filter((item) => !item.roles || item.roles.includes(tier))
+          .filter((item) => !item.roles || item.roles.includes(role))
           .map((item, idx) => (
             <NavLink
               key={idx}

--- a/src/components/common/__tests__/Sidebar.test.jsx
+++ b/src/components/common/__tests__/Sidebar.test.jsx
@@ -5,12 +5,12 @@ import { AuthContext } from '../../../context/AuthContext';
 import { UserProfileContext } from '../../../context/UserProfileContext';
 import { SidebarContext } from '../../../context/SidebarContext';
 
-function renderSidebar(tier = 'admin', isOpen = true, opts = {}) {
+function renderSidebar(role = 'admin', isOpen = true, opts = {}) {
   const logout = opts.logout || jest.fn();
   const logoutProfile = opts.logoutProfile || jest.fn();
   render(
-    <AuthContext.Provider value={{ user: { role: tier }, logout }}>
-      <UserProfileContext.Provider value={{ profile: { tier, name: 'Test User' }, logoutProfile }}>
+    <AuthContext.Provider value={{ user: { role }, logout }}>
+      <UserProfileContext.Provider value={{ profile: { role, name: 'Test User' }, logoutProfile }}>
         <SidebarContext.Provider value={{ isOpen }}>
           <MemoryRouter>
             <Sidebar />

--- a/src/components/kanban/KanbanBoard.jsx
+++ b/src/components/kanban/KanbanBoard.jsx
@@ -26,12 +26,12 @@ const KanbanBoard = () => {
     if (error) console.error("Fetch Error", error);
 
     const visibleTasks =
-      profile?.tier === "admin"
+      profile?.role === "admin"
         ? data
         : data.filter((t) => t.created_by === profile?.id);
 
     setTasks(visibleTasks);
-  }, [profile?.id, profile?.tier]);
+  }, [profile?.id, profile?.role]);
 
   // Initial + Real-time Sync
   useEffect(() => {

--- a/src/components/kanban/__tests__/KanbanBoard.test.jsx
+++ b/src/components/kanban/__tests__/KanbanBoard.test.jsx
@@ -40,7 +40,7 @@ test('handles failed subscription gracefully', async () => {
   const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
 
   const { unmount } = render(
-    <UserProfileContext.Provider value={{ profile: { id: '1', tier: 'admin' } }}>
+    <UserProfileContext.Provider value={{ profile: { id: '1', role: 'admin' } }}>
       <KanbanBoard />
     </UserProfileContext.Provider>
   );

--- a/src/components/reminders/ReminderList.jsx
+++ b/src/components/reminders/ReminderList.jsx
@@ -25,13 +25,13 @@ const ReminderList = () => {
     }
 
     const filtered =
-      profile?.tier === "admin" || profile?.tier === "superadmin"
+      profile?.role === "admin" || profile?.role === "super_admin"
         ? data
         : data.filter((r) => r.created_by === profile?.id);
 
     setReminders(filtered || []);
     setErrorMsg("");
-  }, [profile?.id, profile?.tier]);
+  }, [profile?.id, profile?.role]);
 
   useEffect(() => {
     if (!profile?.id) return;

--- a/src/components/reminders/__tests__/ReminderList.test.jsx
+++ b/src/components/reminders/__tests__/ReminderList.test.jsx
@@ -54,7 +54,7 @@ beforeEach(() => {
 
 const renderList = () =>
   render(
-    <UserProfileContext.Provider value={{ profile: { id: '1', tier: 'admin', name: 'Test' } }}>
+    <UserProfileContext.Provider value={{ profile: { id: '1', role: 'admin', name: 'Test' } }}>
       <ReminderList />
     </UserProfileContext.Provider>
   );

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -39,7 +39,14 @@ export const AuthProvider = ({ children }) => {
 
   return (
     <AuthContext.Provider
-      value={{ currentUser, isLoading, login, logout, register }}
+      value={{
+        currentUser,
+        user: currentUser, // alias for backwards compatibility
+        isLoading,
+        login,
+        logout,
+        register,
+      }}
     >
       {children}
     </AuthContext.Provider>

--- a/src/context/UserProfileContext.js
+++ b/src/context/UserProfileContext.js
@@ -44,7 +44,7 @@ export const UserProfileProvider = ({ children }) => {
           return;
         }
         const { data, error } = await supabase
-          .from("profiles")
+          .from("user_profiles")
           .select("*")
           .eq("id", user.id)
           .single();

--- a/src/data/roles.json
+++ b/src/data/roles.json
@@ -1,6 +1,6 @@
 {
   "roles": {
-    "superadmin": {
+    "super_admin": {
       "modules": [
         { "id": "kanban", "label": "Kanban Board", "desc": "Task management with drag & drop." },
         { "id": "calendar", "label": "Calendar", "desc": "Plan and view project schedules." },
@@ -19,7 +19,7 @@
         { "id": "brands", "label": "Brand Management", "desc": "Manage client brands." }
       ]
     },
-    "client": {
+    "member": {
       "modules": [
         { "id": "kanban", "label": "Kanban Board", "desc": "Task updates & project overview." },
         { "id": "agent", "label": "AI Agent", "desc": "Generate marketing drafts." }

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import AOS from "aos";
 import "aos/dist/aos.css";
 import { AnimatePresence } from "framer-motion";
 import ErrorBoundary from "./components/common/ErrorBoundary.jsx";
+import CustomCursor from "./components/common/CustomCursor.jsx";
 import * as serviceWorkerRegistration from "./serviceWorkerRegistration";
 
 // Initialize AOS on load
@@ -22,6 +23,7 @@ root.render(
   <React.StrictMode>
     <AnimatePresence mode="wait">
       <ErrorBoundary>
+        <CustomCursor />
         <App />
       </ErrorBoundary>
     </AnimatePresence>

--- a/src/pages/BlogManagement.jsx
+++ b/src/pages/BlogManagement.jsx
@@ -6,10 +6,10 @@ import BlogList from "../components/blog/BlogList.jsx";
 
 const BlogManagement = () => {
   const { profile } = useContext(UserProfileContext);
-  const tier = profile?.tier || "guest";
+  const role = profile?.role || "guest";
 
   const renderContent = () => {
-    if (tier === "admin") {
+    if (role === "admin") {
       return (
         <div className="bg-white/5 p-6 border border-white/10 rounded-xl shadow-lg">
           <BlogManager />
@@ -17,7 +17,7 @@ const BlogManagement = () => {
       );
     }
 
-    if (tier === "client") {
+    if (role === "member") {
       return (
         <div className="bg-white/5 p-6 border border-white/10 rounded-xl shadow-lg">
           <BlogList posts={profile?.blogPreviews || []} />

--- a/src/pages/ClientsPage.jsx
+++ b/src/pages/ClientsPage.jsx
@@ -47,8 +47,8 @@ export default function ClientsPage() {
     setUserClient(c);
     setShowUsers(true);
     const { data: users } = await supabase
-      .from('profiles')
-      .select('id, email, name, tier');
+      .from('user_profiles')
+      .select('id, email, full_name, role');
     setAllUsers(users || []);
     const { data: assigned } = await supabase
       .from('client_users')
@@ -250,7 +250,7 @@ export default function ClientsPage() {
                       }
                     }}
                   />
-                  {u.email} ({u.tier})
+                  {u.email} ({u.role})
                 </label>
               ))}
             </div>

--- a/src/pages/ProfileSettings.jsx
+++ b/src/pages/ProfileSettings.jsx
@@ -15,7 +15,7 @@ const ProfileSettings = () => {
 
     const updates = { bio, experience, social_links: social };
     const { data, error } = await supabase
-      .from("profiles")
+      .from("user_profiles")
       .update(updates)
       .eq("id", profile.id)
       .select()

--- a/src/pages/ProfileSetup.jsx
+++ b/src/pages/ProfileSetup.jsx
@@ -35,15 +35,15 @@ const ProfileSetup = () => {
       name,
       company,
       avatar,
-      tier:
+      role:
         supaUser.email === "sajal@fedrixgroup.com"
-          ? "superadmin"
+          ? "super_admin"
           : supaUser.email.includes("admin")
             ? "admin"
-            : "client",
+            : "member",
     };
 
-    await supabase.from("profiles").upsert(profileData);
+    await supabase.from("user_profiles").upsert(profileData);
     saveProfile(profileData);
     navigate("/dashboard");
   };

--- a/src/pages/__tests__/Dashboard.test.jsx
+++ b/src/pages/__tests__/Dashboard.test.jsx
@@ -49,7 +49,7 @@ function renderWithRole(role) {
 
 describe('Dashboard module visibility', () => {
   test('superadmin sees all standard modules', () => {
-    renderWithRole('superadmin');
+    renderWithRole('super_admin');
     expect(screen.getByText(/Taskboard/i)).toBeInTheDocument();
     expect(screen.getByText(/Calendar/i)).toBeInTheDocument();
     expect(screen.getByText(/Blog Manager/i)).toBeInTheDocument();

--- a/src/pages/__tests__/UserManagement.test.jsx
+++ b/src/pages/__tests__/UserManagement.test.jsx
@@ -28,7 +28,7 @@ const renderWithProfile = (ui, profile) => {
 
 describe('UserManagement', () => {
   test('renders management interface', () => {
-    renderWithProfile(<UserManagement />, { tier: 'superadmin' });
+    renderWithProfile(<UserManagement />, { role: 'super_admin' });
     expect(screen.getByText('User Management')).toBeInTheDocument();
     expect(screen.getByText('Create User')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- update `AuthContext` to expose `user`
- fetch profiles from `user_profiles` table
- fix login form and protected routes
- integrate custom cursor globally
- adjust role logic across components and tests

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eef87e7fc83338547fbdf1cb3c354