### PR TITLE
Update layout and remove profile setup

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,7 +12,6 @@ import BlogManagement from "./pages/BlogManagement.jsx";
 import AgentAIDashboard from "./components/ai/AgentDashboard.jsx";
 import UserManagement from "./components/admin/UserManagement.jsx";
 import ClientsPage from "./pages/ClientsPage.jsx";
-import ProfileSetup from "./pages/ProfileSetup.jsx";
 import Profile from "./pages/Profile.jsx";
 import ProfileSettings from "./pages/ProfileSettings.jsx";
 import { AuthProvider } from "./context/AuthContext";
@@ -39,10 +38,6 @@ const App = () => {
           {
             path: '/login',
             element: <Login />,
-          },
-          {
-            path: '/profile',
-            element: <ProfileSetup />,
           },
           {
             path: '/dashboard/profile',

--- a/src/components/common/DashboardLayout.jsx
+++ b/src/components/common/DashboardLayout.jsx
@@ -2,6 +2,7 @@ import React, { useContext } from "react";
 import PropTypes from "prop-types";
 import Sidebar from "./Sidebar.jsx";
 import Header from "./Header.jsx";
+import Footer from "./Footer.jsx";
 import { SidebarContext } from "../../context/SidebarContext";
 
 const DashboardLayout = ({ children }) => {
@@ -9,9 +10,10 @@ const DashboardLayout = ({ children }) => {
   return (
     <>
       <Sidebar />
-      <div className={`dashboard-main ${isOpen ? 'ml-[220px]' : 'ml-0'}`}>
+      <div className={`dashboard-main ${isOpen ? 'ml-56' : 'ml-20'} min-h-screen flex flex-col`}>
         <Header />
-        {children}
+        <div className="flex-1">{children}</div>
+        <Footer />
       </div>
     </>
   );

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -1,15 +1,32 @@
 import React, { useContext } from "react";
 import { motion } from "framer-motion";
 import { HiMenuAlt3 } from "react-icons/hi";
+import { useLocation } from "react-router-dom";
 import { UserProfileContext } from "../../context/UserProfileContext";
 import { SidebarContext } from "../../context/SidebarContext";
 import UserMenu from "./UserMenu.jsx";
+import HologramTitle from "./HologramTitle.jsx";
 
 const Header = () => {
   const { profile } = useContext(UserProfileContext);
+  const location = useLocation();
 
   const { toggleSidebar } = useContext(SidebarContext);
   const tier = profile?.role || "guest";
+
+  const pageTitles = {
+    "/dashboard": "Dashboard",
+    "/dashboard/kanban": "Kanban Board",
+    "/dashboard/calendar": "Calendar",
+    "/dashboard/blog": "Blog",
+    "/dashboard/agent": "AI Agent",
+    "/dashboard/reminders": "Reminders",
+    "/dashboard/clients": "Brands",
+    "/dashboard/users": "Users",
+    "/dashboard/profile": "Profile",
+    "/dashboard/settings": "Settings",
+  };
+  const title = pageTitles[location.pathname] || "Fedrix Vision";
 
   return (
     <motion.header
@@ -22,9 +39,7 @@ const Header = () => {
         <button onClick={toggleSidebar} className="text-white focus:outline-none">
           <HiMenuAlt3 className="text-2xl" />
         </button>
-        <div className="text-lg font-bold text-gray-300 tracking-wide">
-          Fedrix Vision
-        </div>
+        <HologramTitle title={title} />
       </div>
 
       <div className="flex items-center gap-4">

--- a/src/components/common/Sidebar.jsx
+++ b/src/components/common/Sidebar.jsx
@@ -1,5 +1,5 @@
 import React, { useContext } from "react";
-import { NavLink, useNavigate } from "react-router-dom";
+import { NavLink } from "react-router-dom";
 import { AuthContext } from "../../context/AuthContext";
 import { UserProfileContext } from "../../context/UserProfileContext";
 import { SidebarContext } from "../../context/SidebarContext";
@@ -10,21 +10,13 @@ import {
   HiOutlineUsers,
   HiOutlineSparkles,
   HiOutlineBell,
-  HiOutlineLogout,
 } from "react-icons/hi";
 
 const Sidebar = () => {
-  const { logout, user } = useContext(AuthContext);
-  const { logoutProfile, profile } = useContext(UserProfileContext);
-  const { isOpen } = useContext(SidebarContext);
-  const navigate = useNavigate();
+  const { user } = useContext(AuthContext);
+  const { profile } = useContext(UserProfileContext);
+  const { isOpen, openSidebar, closeSidebar } = useContext(SidebarContext);
   const role = profile?.role || user?.role || "user";
-
-  const handleLogout = () => {
-    logout();
-    logoutProfile();
-    navigate("/login");
-  };
 
   const navItems = [
     { to: "/dashboard", icon: <HiViewBoards />, label: "Dashboard" },
@@ -39,11 +31,13 @@ const Sidebar = () => {
 
   return (
     <aside
-      className={`fixed top-0 left-0 h-full bg-black border-r border-white/10 px-6 py-8 z-50 shadow-xl overflow-x-hidden transition-all duration-300 ${
-        isOpen ? "w-56 translate-x-0" : "w-0 -translate-x-full"
+      onMouseEnter={openSidebar}
+      onMouseLeave={closeSidebar}
+      className={`fixed top-0 left-0 h-full bg-black border-r border-white/10 px-4 py-8 z-50 shadow-xl overflow-x-hidden transition-all duration-300 ${
+        isOpen ? "w-56" : "w-20"
       }`}
     >
-      <div className="text-center mb-10">
+      <div className="text-center mb-10 whitespace-nowrap">
         <h1 className="text-gray-300 text-xl font-bold">Fedrix Vision</h1>
         <p className="text-white/40 text-xs mt-1">Welcome, {profile?.name?.split(" ")[0]}</p>
       </div>
@@ -64,20 +58,11 @@ const Sidebar = () => {
               }
             >
               <span className="text-lg">{item.icon}</span>
-              {item.label}
+              <span className={`${isOpen ? "inline" : "hidden"}`}>{item.label}</span>
             </NavLink>
           ))}
       </nav>
 
-      <div className="absolute bottom-6 w-full left-0 px-6">
-        <button
-          onClick={handleLogout}
-          className="flex items-center gap-2 w-full text-white/70 hover:text-red-500 transition-all"
-        >
-          <HiOutlineLogout className="text-lg" />
-          Logout
-        </button>
-      </div>
     </aside>
   );
 };

--- a/src/components/common/UserMenu.jsx
+++ b/src/components/common/UserMenu.jsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState } from 'react';
 
-import { useNavigate, Navigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { UserProfileContext } from '../../context/UserProfileContext';
 import { AuthContext } from '../../context/AuthContext';
@@ -17,9 +17,6 @@ const UserMenu = () => {
     navigate('/login');
   };
 
-  if (!profile?.name) {
-    return <Navigate to="/profile" replace />;
-  }
 
   return (
     <div>

--- a/src/components/common/UserProfileDropdown.jsx
+++ b/src/components/common/UserProfileDropdown.jsx
@@ -78,14 +78,14 @@ const UserProfileDropdown = ({ signOut, onClose }) => {
         </div>
       </div>
       <NavLink
-        to="/profile"
+        to="/dashboard/profile"
         className="flex items-center p-2 rounded-md hover:bg-mid-gray transition-colors mb-1 text-white/90"
         onClick={onClose}
       >
         <FaUserCircle className="mr-3" /> My Profile
       </NavLink>
       <NavLink
-        to="/settings"
+        to="/dashboard/settings"
         className="flex items-center p-2 rounded-md hover:bg-mid-gray transition-colors mb-1 text-white/90"
         onClick={onClose}
       >

--- a/src/context/SidebarContext.js
+++ b/src/context/SidebarContext.js
@@ -4,10 +4,16 @@ import PropTypes from "prop-types";
 export const SidebarContext = createContext();
 
 export const SidebarProvider = ({ children }) => {
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
+
   const toggleSidebar = () => setIsOpen((prev) => !prev);
+  const openSidebar = () => setIsOpen(true);
+  const closeSidebar = () => setIsOpen(false);
+
   return (
-    <SidebarContext.Provider value={{ isOpen, toggleSidebar }}>
+    <SidebarContext.Provider
+      value={{ isOpen, toggleSidebar, openSidebar, closeSidebar }}
+    >
       {children}
     </SidebarContext.Provider>
   );

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,6 +1,5 @@
 import React, { useContext } from "react";
 import { UserProfileContext } from "../context/UserProfileContext";
-import { SidebarContext } from "../context/SidebarContext";
 import { motion } from "framer-motion";
 import {
   StatCard,
@@ -15,22 +14,19 @@ import KanbanWidget from "../components/widgets/KanbanWidget.js";
 
 const Dashboard = () => {
   const { profile } = useContext(UserProfileContext);
-  const { isOpen } = useContext(SidebarContext);
 
   const firstName = profile?.name?.split(" ")[0] || "User";
 
   return (
-    <div className="dashboard-wrapper">
-      <div className={`dashboard-main ${isOpen ? 'ml-[220px]' : 'ml-0'}`}>
-        <div className="dashboard-content space-y-10">
-          <motion.div
-            className="text-white text-2xl font-semibold tracking-wide"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8 }}
-          >
-            👋 Welcome back, <span className="text-gray-300">{firstName}</span>
-          </motion.div>
+    <div className="dashboard-content space-y-10">
+      <motion.div
+        className="text-white text-2xl font-semibold tracking-wide"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.8 }}
+      >
+        👋 Welcome back, <span className="text-gray-300">{firstName}</span>
+      </motion.div>
 
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
             <StatCard
@@ -66,13 +62,7 @@ const Dashboard = () => {
             <RecentActivityFeed />
           </div>
 
-          <KanbanWidget />
-        </div>
-
-        <footer className="text-center mt-10 text-white/30 text-sm">
-          ⓒ {new Date().getFullYear()} Fedrix MediaLab. All rights reserved.
-        </footer>
-      </div>
+      <KanbanWidget />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- simplify routing by removing the profile setup page
- add footer and dynamic hologram title in the header
- update sidebar with hover expansion and remove logout button
- adjust dashboard layout and page structure
- expose sidebar open/close helpers in context

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef56f0f688333ba163ea635d52b6f