### PR TITLE
Implement UI updates for sidebar and widgets

### DIFF
--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -1,17 +1,23 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { motion } from "framer-motion";
-import { HiMenuAlt3 } from "react-icons/hi";
+import { HiMenuAlt3, HiChevronDown } from "react-icons/hi";
 import { useLocation } from "react-router-dom";
 import { UserProfileContext } from "../../context/UserProfileContext";
 import { SidebarContext } from "../../context/SidebarContext";
-import UserMenu from "./UserMenu.jsx";
+import UserProfileDropdown from "./UserProfileDropdown.jsx";
+import NotificationsDropdown from "./NotificationsDropdown.jsx";
+import { useAuth } from "../../context/AuthContext";
+import { useNavigate } from "react-router-dom";
 import HologramTitle from "./HologramTitle.jsx";
+import logo from "../../assets/fedrix.svg";
 
 const Header = () => {
-  const { profile } = useContext(UserProfileContext);
+  const { profile, logoutProfile } = useContext(UserProfileContext);
   const location = useLocation();
 
   const { toggleSidebar } = useContext(SidebarContext);
+  const { logout } = useAuth();
+  const navigate = useNavigate();
   const tier = profile?.role || "guest";
 
   const pageTitles = {
@@ -28,6 +34,20 @@ const Header = () => {
   };
   const title = pageTitles[location.pathname] || "Fedrix Vision";
 
+  const [dateTime, setDateTime] = useState(new Date());
+  const [openProfile, setOpenProfile] = useState(false);
+
+  const handleSignOut = () => {
+    logout();
+    logoutProfile();
+    navigate('/login');
+  };
+
+  useEffect(() => {
+    const t = setInterval(() => setDateTime(new Date()), 60000);
+    return () => clearInterval(t);
+  }, []);
+
   return (
     <motion.header
       className="w-full flex items-center justify-between px-8 py-4 border-b border-white/10 backdrop-blur-xl bg-white/5 z-20"
@@ -39,15 +59,41 @@ const Header = () => {
         <button onClick={toggleSidebar} className="text-white focus:outline-none">
           <HiMenuAlt3 className="text-2xl" />
         </button>
+        <img src={logo} alt="Fedrix" className="h-6 w-6" />
+        <span className="text-white font-semibold">Vision Suite</span>
         <HologramTitle title={title} />
       </div>
 
-      <div className="flex items-center gap-4">
-        {/* Tier badge */}
+      <div className="flex items-center gap-4 relative">
+        <span className="text-xs text-white/80 font-mono">
+          {dateTime.toLocaleString()}
+        </span>
+        <NotificationsDropdown />
         <div className="text-white/80 text-xs bg-gray-700/10 px-3 py-1 rounded-full border border-gray-700 uppercase tracking-wide">
           {tier}
         </div>
-        <UserMenu />
+        <div className="relative">
+          <button
+            onClick={() => setOpenProfile((o) => !o)}
+            className="flex items-center space-x-2 focus:outline-none"
+          >
+            {profile?.avatar && (
+              <img
+                src={profile.avatar}
+                alt="avatar"
+                className="w-6 h-6 rounded-full object-cover"
+              />
+            )}
+            <span className="whitespace-nowrap">{profile?.name}</span>
+            <HiChevronDown className="text-white" />
+          </button>
+          {openProfile && (
+            <UserProfileDropdown
+              signOut={handleSignOut}
+              onClose={() => setOpenProfile(false)}
+            />
+          )}
+        </div>
       </div>
     </motion.header>
   );

--- a/src/components/common/Sidebar.jsx
+++ b/src/components/common/Sidebar.jsx
@@ -33,13 +33,12 @@ const Sidebar = () => {
     <aside
       onMouseEnter={openSidebar}
       onMouseLeave={closeSidebar}
-      className={`fixed top-0 left-0 h-full bg-black border-r border-white/10 px-4 py-8 z-50 shadow-xl overflow-x-hidden transition-all duration-300 ${
+      className={`fixed left-0 top-16 bottom-12 bg-black border-r border-white/10 px-4 py-8 z-50 shadow-xl overflow-x-hidden transition-all duration-300 ${
         isOpen ? "w-56" : "w-20"
       }`}
     >
       <div className="text-center mb-10 whitespace-nowrap">
         <h1 className="text-gray-300 text-xl font-bold">Fedrix Vision</h1>
-        <p className="text-white/40 text-xs mt-1">Welcome, {profile?.name?.split(" ")[0]}</p>
       </div>
 
       <nav className="flex flex-col space-y-4">

--- a/src/components/common/UserMenu.jsx
+++ b/src/components/common/UserMenu.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { UserProfileContext } from '../../context/UserProfileContext';
 import { AuthContext } from '../../context/AuthContext';
+import { HiChevronDown } from 'react-icons/hi';
 
 const UserMenu = () => {
   const { profile, logoutProfile } = useContext(UserProfileContext);
@@ -19,20 +20,28 @@ const UserMenu = () => {
 
 
   return (
-    <div>
-      <button onClick={() => setOpen(!open)} data-testid="menu-toggle">
+    <div className="relative">
+      <button
+        onClick={() => setOpen(!open)}
+        data-testid="menu-toggle"
+        className="flex items-center space-x-2 focus:outline-none"
+      >
         {profile.avatar && (
           <img
             src={profile.avatar}
             alt="avatar"
-            className="w-6 h-6 rounded-full inline-block mr-2"
+            className="w-6 h-6 rounded-full inline-block"
             data-testid="avatar-img"
           />
         )}
-        {profile.name}
+        <span className="whitespace-nowrap">{profile.name}</span>
+        <HiChevronDown className="text-white" />
       </button>
       {open && (
-        <ul data-testid="menu-list">
+        <ul
+          data-testid="menu-list"
+          className="absolute right-0 mt-2 bg-black/80 backdrop-blur-sm border border-white/10 rounded-md py-2 w-32 text-sm"
+        >
           <li>
             <button
               data-testid="profile-link"
@@ -40,12 +49,19 @@ const UserMenu = () => {
                 setOpen(false);
                 navigate('/dashboard/profile');
               }}
+              className="block w-full text-left px-4 py-2 hover:bg-white/10"
             >
               Profile
             </button>
           </li>
           <li>
-            <button data-testid="logout-button" onClick={handleLogout}>Logout</button>
+            <button
+              data-testid="logout-button"
+              onClick={handleLogout}
+              className="block w-full text-left px-4 py-2 hover:bg-white/10"
+            >
+              Logout
+            </button>
           </li>
         </ul>
       )}

--- a/src/components/dashboard/AIChatWidget.jsx
+++ b/src/components/dashboard/AIChatWidget.jsx
@@ -93,8 +93,8 @@ const AIChatWidget = ({ className }) => {
 
   return (
     <div
-      className={`hologram-tile p-6 flex flex-col ${className || ''}
-                    bg-gradient-to-br from-dark-gray/60 to-black-ops/60`}
+      className={`glassy-tile p-6 flex flex-col ${className || ''}
+                    bg-gradient-to-br from-cyan-900/60 via-blue-900/30 to-cyan-800/50`}
     >
       <h3 className="text-lg font-semibold text-white/80 mb-4 pb-2 border-b border-indigo-600/30 flex items-center justify-between">
         Agent AI Chat

--- a/src/components/dashboard/RecentActivityFeed.jsx
+++ b/src/components/dashboard/RecentActivityFeed.jsx
@@ -284,8 +284,8 @@ const RecentActivityFeed = ({ className }) => {
 
   return (
     <div
-      className={`hologram-tile p-6 flex flex-col ${className || ''}
-                    bg-gradient-to-br from-dark-gray/60 to-black-ops/60`}
+      className={`glassy-tile p-6 flex flex-col ${className || ''}
+                    bg-gradient-to-br from-teal-900/60 via-indigo-900/30 to-teal-800/50`}
     >
       <h3 className="text-lg font-semibold text-white/80 mb-4 pb-2 border-b border-blue-600/30">
         Recent Activity

--- a/src/components/dashboard/StatCard.jsx
+++ b/src/components/dashboard/StatCard.jsx
@@ -76,35 +76,42 @@ const StarIcon = (props) => (
   </svg>
 );
 
-const StatCard = ({ title, value, description, icon: Icon, className }) => {
+const StatCard = ({
+  title,
+  value,
+  description,
+  icon: Icon,
+  className,
+  gradient = "from-cyan-700/60 to-cyan-900/60",
+}) => {
   return (
     <motion.div
-      className={`hologram-tile py-4 px-5 flex flex-col justify-between items-start rounded-xl shadow-lg border border-mid-gray
+      className={`hologram-tile py-4 px-5 flex items-center rounded-xl shadow-lg border border-mid-gray
                   transition-all duration-300 ease-in-out hover:shadow-2xl hover:border-teal-500
-                  bg-gradient-to-br from-dark-gray/60 to-black-ops/60 group ${className}`}
-      whileHover={{ y: -3, scale: 1.01 }} // Subtle lift and scale on hover
+                  bg-gradient-to-br ${gradient} group ${className}`}
+      whileHover={{ y: -3, scale: 1.01 }}
     >
-      <div className="flex items-center justify-between w-full mb-1">
+      {Icon && (
+        <motion.div
+          initial={{ scale: 0.8, opacity: 0.7 }}
+          animate={{ scale: 1, opacity: 1 }}
+          transition={{ duration: 0.5, delay: 0.1 }}
+          className="flex-shrink-0 mr-4"
+        >
+          <Icon className="text-white opacity-80 group-hover:opacity-100 transition-opacity duration-300 w-8 h-8" />
+        </motion.div>
+      )}
+      <div className="flex flex-col">
         <h3 className="text-xs sm:text-sm font-semibold text-white/70 uppercase tracking-wide">
           {title}
         </h3>
-        {Icon && (
-          <motion.div
-            initial={{ scale: 0.8, opacity: 0.7 }}
-            animate={{ scale: 1, opacity: 1 }}
-            transition={{ duration: 0.5, delay: 0.1 }}
-            className="flex-shrink-0"
-          >
-            <Icon className="text-teal-400 opacity-70 group-hover:opacity-100 transition-opacity duration-300" />
-          </motion.div>
-        )}
+        <p className="text-2xl sm:text-3xl font-extrabold text-white mb-1">
+          {value}
+        </p>
+        <p className="text-[10px] sm:text-xs text-light-gray leading-tight">
+          {description}
+        </p>
       </div>
-      <p className="text-2xl sm:text-3xl font-extrabold text-white mb-1">
-        {value}
-      </p>
-      <p className="text-[10px] sm:text-xs text-light-gray leading-tight">
-        {description}
-      </p>
     </motion.div>
   );
 };
@@ -115,6 +122,7 @@ StatCard.propTypes = {
   description: PropTypes.string.isRequired,
   icon: PropTypes.elementType.isRequired,
   className: PropTypes.string,
+  gradient: PropTypes.string,
 };
 
 export { StatCard, DollarSignIcon, UsersIcon, CheckSquareIcon, StarIcon };

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,6 +1,4 @@
-import React, { useContext } from "react";
-import { UserProfileContext } from "../context/UserProfileContext";
-import { motion } from "framer-motion";
+import React from "react";
 import {
   StatCard,
   DollarSignIcon,
@@ -13,45 +11,37 @@ import RecentActivityFeed from "../components/dashboard/RecentActivityFeed.jsx";
 import KanbanWidget from "../components/widgets/KanbanWidget.js";
 
 const Dashboard = () => {
-  const { profile } = useContext(UserProfileContext);
-
-  const firstName = profile?.name?.split(" ")[0] || "User";
 
   return (
     <div className="dashboard-content space-y-10">
-      <motion.div
-        className="text-white text-2xl font-semibold tracking-wide"
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.8 }}
-      >
-        👋 Welcome back, <span className="text-gray-300">{firstName}</span>
-      </motion.div>
-
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
             <StatCard
               title="Projects"
               value="12"
               description="Active"
               icon={CheckSquareIcon}
+              gradient="from-pink-700/60 to-pink-900/60"
             />
             <StatCard
               title="Clients"
               value="8"
               description="Engaged"
               icon={UsersIcon}
+              gradient="from-purple-700/60 to-purple-900/60"
             />
             <StatCard
               title="Revenue"
               value="$24k"
               description="This Month"
               icon={DollarSignIcon}
+              gradient="from-amber-600/60 to-amber-800/60"
             />
             <StatCard
               title="Rating"
               value="4.9"
               description="Average"
               icon={StarIcon}
+              gradient="from-teal-700/60 to-teal-900/60"
             />
           </div>
 


### PR DESCRIPTION
## Summary
- integrate `UserProfileDropdown` and `NotificationsDropdown` in the header
- keep sidebar between header and footer
- add gradient prop to `StatCard` and apply unique colors
- convert AI chat and recent activity widgets to glassy tiles

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run lint` *(fails: eslint-plugin-react missing)*

------
https://chatgpt.com/codex/tasks/task_e_685efa8ceb588333b652217fd38d5d40