### PR TITLE
UI tweaks for dashboard

### DIFF
--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -1,9 +1,8 @@
 import React, { useContext, useEffect, useState } from "react";
 import { motion } from "framer-motion";
-import { HiMenuAlt3, HiChevronDown } from "react-icons/hi";
+import { HiChevronDown } from "react-icons/hi";
 import { useLocation } from "react-router-dom";
 import { UserProfileContext } from "../../context/UserProfileContext";
-import { SidebarContext } from "../../context/SidebarContext";
 import UserProfileDropdown from "./UserProfileDropdown.jsx";
 import NotificationsDropdown from "./NotificationsDropdown.jsx";
 import { useAuth } from "../../context/AuthContext";
@@ -15,7 +14,6 @@ const Header = () => {
   const { profile, logoutProfile } = useContext(UserProfileContext);
   const location = useLocation();
 
-  const { toggleSidebar } = useContext(SidebarContext);
   const { logout } = useAuth();
   const navigate = useNavigate();
   const tier = profile?.role || "guest";
@@ -57,11 +55,11 @@ const Header = () => {
       transition={{ duration: 0.6 }}
     >
       <div className="flex items-center gap-4">
-        <button onClick={toggleSidebar} className="text-white focus:outline-none">
-          <HiMenuAlt3 className="text-2xl" />
-        </button>
-        <img src={logo} alt="Fedrix" className="h-6 w-6" />
-        <span className="text-white font-semibold">Vision Suite</span>
+        <img src={logo} alt="Fedrix" className="h-8 w-8" />
+        <span className="font-semibold">
+          <span className="text-transparent bg-gradient-to-r from-cyan-300 to-teal-400 bg-clip-text">Vision</span>{' '}
+          <span className="text-white">Suite</span>
+        </span>
         <HologramTitle title={title} />
       </div>
 
@@ -86,7 +84,7 @@ const Header = () => {
                 className="w-6 h-6 rounded-full object-cover"
               />
             )}
-            <span className="whitespace-nowrap">{profile?.name}</span>
+            <span className="whitespace-nowrap">{profile?.full_name || profile?.name || profile?.email}</span>
             <HiChevronDown className="text-white" />
           </button>
           {openProfile && (

--- a/src/components/common/Sidebar.jsx
+++ b/src/components/common/Sidebar.jsx
@@ -33,7 +33,7 @@ const Sidebar = () => {
     <aside
       onMouseEnter={openSidebar}
       onMouseLeave={closeSidebar}
-      className={`fixed left-0 top-16 bottom-12 bg-black border-r border-white/10 px-4 py-8 z-50 shadow-xl overflow-x-hidden transition-all duration-300 ${
+      className={`fixed left-0 top-20 bottom-12 bg-black border-r border-white/10 px-4 py-8 z-50 shadow-xl overflow-x-hidden transition-all duration-300 ${
         isOpen ? "w-56" : "w-20"
       }`}
     >
@@ -51,8 +51,8 @@ const Sidebar = () => {
               className={({ isActive }) =>
                 `flex items-center gap-3 px-4 py-2 rounded-md transition-all text-white ${
                   isActive
-                    ? "bg-gray-700 font-semibold shadow-md"
-                    : "hover:bg-white/10 hover:text-gray-300"
+                    ? 'bg-gradient-to-r from-cyan-600 to-teal-600 font-semibold shadow-md'
+                    : 'hover:bg-white/10 hover:text-gray-300'
                 }`
               }
             >

--- a/src/components/dashboard/AIChatWidget.jsx
+++ b/src/components/dashboard/AIChatWidget.jsx
@@ -93,7 +93,7 @@ const AIChatWidget = ({ className }) => {
 
   return (
     <div
-      className={`glassy-tile p-6 flex flex-col ${className || ''}
+      className={`glassy-tile rounded-xl shadow-2xl min-h-[420px] p-6 flex flex-col ${className || ''}
                     bg-gradient-to-br from-cyan-900/60 via-blue-900/30 to-cyan-800/50`}
     >
       <h3 className="text-lg font-semibold text-white/80 mb-4 pb-2 border-b border-indigo-600/30 flex items-center justify-between">

--- a/src/components/dashboard/RecentActivityFeed.jsx
+++ b/src/components/dashboard/RecentActivityFeed.jsx
@@ -284,7 +284,7 @@ const RecentActivityFeed = ({ className }) => {
 
   return (
     <div
-      className={`glassy-tile p-6 flex flex-col ${className || ''}
+      className={`glassy-tile rounded-xl shadow-2xl min-h-[420px] p-6 flex flex-col ${className || ''}
                     bg-gradient-to-br from-teal-900/60 via-indigo-900/30 to-teal-800/50`}
     >
       <h3 className="text-lg font-semibold text-white/80 mb-4 pb-2 border-b border-blue-600/30">

--- a/src/index.css
+++ b/src/index.css
@@ -81,3 +81,12 @@ footer {
     transform: translateY(0);
   }
 }
+
+/* Reusable tile styles */
+.glassy-tile {
+  @apply backdrop-blur-lg border border-white/10 bg-white/5 rounded-xl;
+}
+
+.hologram-tile {
+  @apply backdrop-blur-lg border border-white/10 bg-black/20 rounded-xl;
+}

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -20,36 +20,36 @@ const Dashboard = () => {
               value="12"
               description="Active"
               icon={CheckSquareIcon}
-              gradient="from-pink-700/60 to-pink-900/60"
+              gradient="from-fuchsia-600/60 to-pink-800/60"
             />
             <StatCard
               title="Clients"
               value="8"
               description="Engaged"
               icon={UsersIcon}
-              gradient="from-purple-700/60 to-purple-900/60"
+              gradient="from-violet-600/60 to-indigo-800/60"
             />
             <StatCard
               title="Revenue"
               value="$24k"
               description="This Month"
               icon={DollarSignIcon}
-              gradient="from-amber-600/60 to-amber-800/60"
+              gradient="from-emerald-600/60 to-teal-800/60"
             />
             <StatCard
               title="Rating"
               value="4.9"
               description="Average"
               icon={StarIcon}
-              gradient="from-teal-700/60 to-teal-900/60"
+              gradient="from-orange-600/60 to-amber-800/60"
             />
           </div>
 
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 items-stretch">
             <div className="lg:col-span-2">
-              <AIChatWidget />
+              <AIChatWidget className="h-full" />
             </div>
-            <RecentActivityFeed />
+            <RecentActivityFeed className="h-full" />
           </div>
 
       <KanbanWidget />


### PR DESCRIPTION
## Summary
- restyle header with larger logo, gradient text and full profile name
- update sidebar top offset and cyan active highlight
- give dashboard stat cards vibrant colors
- apply glass tiles to chat and activity widgets with equal height
- add reusable CSS for tiles

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f026b4c0483338ae6d511c8748d6b