### PR TITLE
Fix header and dropdown UI

### DIFF
--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -49,7 +49,7 @@ const Header = () => {
 
   return (
     <motion.header
-      className="w-full flex items-center justify-between px-8 py-4 border-b border-white/10 backdrop-blur-xl bg-white/5 z-20"
+      className="fixed top-0 left-0 right-0 w-full flex items-center justify-between px-8 py-4 border-b border-white/10 backdrop-blur-xl bg-white/5 z-40"
       initial={{ y: -50, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}
       transition={{ duration: 0.6 }}
@@ -77,13 +77,11 @@ const Header = () => {
             onClick={() => setOpenProfile((o) => !o)}
             className="flex items-center space-x-2 focus:outline-none"
           >
-            {profile?.avatar && (
-              <img
-                src={profile.avatar}
-                alt="avatar"
-                className="w-6 h-6 rounded-full object-cover"
-              />
-            )}
+            <img
+              src={profile?.avatar || 'https://placehold.co/40/00bf8b/FFFFFF?text=AV'}
+              alt="avatar"
+              className="w-6 h-6 rounded-full object-cover"
+            />
             <span className="whitespace-nowrap">{profile?.full_name || profile?.name || profile?.email}</span>
             <HiChevronDown className="text-white" />
           </button>

--- a/src/components/common/UserProfileDropdown.jsx
+++ b/src/components/common/UserProfileDropdown.jsx
@@ -39,14 +39,14 @@ const UserProfileDropdown = ({ signOut, onClose }) => {
 
   if (isLoadingProfile) {
     return (
-      <div className="absolute right-0 mt-2 w-64 bg-dark-gray border border-mid-gray rounded-lg shadow-xl p-4 text-sm text-white/90 z-40">
+      <div className="absolute right-0 mt-2 w-64 bg-black/80 backdrop-blur-lg border border-mid-gray rounded-lg shadow-xl p-4 text-sm text-white/90 z-40">
         Loading profile...
       </div>
     );
   }
   if (profileError) {
     return (
-      <div className="absolute right-0 mt-2 w-64 bg-dark-gray border border-mid-gray rounded-lg shadow-xl p-4 text-sm text-red-400 z-40">
+      <div className="absolute right-0 mt-2 w-64 bg-black/80 backdrop-blur-lg border border-mid-gray rounded-lg shadow-xl p-4 text-sm text-red-400 z-40">
         Error loading profile.
       </div>
     );
@@ -58,7 +58,7 @@ const UserProfileDropdown = ({ signOut, onClose }) => {
       initial={{ opacity: 0, y: -10 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -10 }}
-      className="absolute right-0 mt-2 w-64 bg-dark-gray border border-mid-gray rounded-lg shadow-xl p-4 text-sm text-white/90 z-40"
+      className="absolute right-0 mt-2 w-64 bg-black/80 backdrop-blur-lg border border-mid-gray rounded-lg shadow-xl p-4 text-sm text-white/90 z-40"
     >
       <div className="flex items-center border-b border-mid-gray pb-3 mb-3">
         <img


### PR DESCRIPTION
## Summary
- keep the dashboard header fixed at the top
- always show a profile picture and provide a placeholder
- darken the profile dropdown background for better visibility

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f050499688333b50c42823105e8f1