### PR TITLE
Implement dynamic layout and new routes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,6 +24,12 @@ import AnimatedBackground from "./components/common/AnimatedBackground.jsx";
 import { AgentAIProvider } from "./context/AgentAIContext";
 import Reminders from "./pages/Reminders.jsx";
 import { NotificationsProvider } from "./context/NotificationsContext";
+import AnalyticsPage from "./pages/AnalyticsPage.jsx";
+import SocialCalendar from "./pages/SocialCalendar.jsx";
+import ApiKeysPage from "./pages/ApiKeysPage.jsx";
+import ToolsPage from "./pages/ToolsPage.jsx";
+import AppSettings from "./pages/AppSettings.jsx";
+import Unauthorized from "./pages/Unauthorized.jsx";
 
 const App = () => {
   const [showSplash, setShowSplash] = useState(true);
@@ -139,6 +145,60 @@ const App = () => {
                 </DashboardLayout>
               </ProtectedRoute>
             ),
+          },
+          {
+            path: '/dashboard/analytics',
+            element: (
+              <ProtectedRoute requiredRole="admin">
+                <DashboardLayout>
+                  <AnalyticsPage />
+                </DashboardLayout>
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: '/dashboard/social-calendar',
+            element: (
+              <ProtectedRoute>
+                <DashboardLayout>
+                  <SocialCalendar />
+                </DashboardLayout>
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: '/dashboard/api-keys',
+            element: (
+              <ProtectedRoute requiredRole="admin">
+                <DashboardLayout>
+                  <ApiKeysPage />
+                </DashboardLayout>
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: '/dashboard/tools',
+            element: (
+              <ProtectedRoute>
+                <DashboardLayout>
+                  <ToolsPage />
+                </DashboardLayout>
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: '/dashboard/app-settings',
+            element: (
+              <ProtectedRoute requiredRole="super_admin">
+                <DashboardLayout>
+                  <AppSettings />
+                </DashboardLayout>
+              </ProtectedRoute>
+            ),
+          },
+          {
+            path: '/unauthorized',
+            element: <Unauthorized />,
           },
         ],
         {

--- a/src/components/common/DashboardLayout.jsx
+++ b/src/components/common/DashboardLayout.jsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useRef, useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import Sidebar from "./Sidebar.jsx";
 import Header from "./Header.jsx";
@@ -7,13 +7,37 @@ import { SidebarContext } from "../../context/SidebarContext";
 
 const DashboardLayout = ({ children }) => {
   const { isOpen } = useContext(SidebarContext);
+  const headerRef = useRef(null);
+  const footerRef = useRef(null);
+  const [offsets, setOffsets] = useState({ header: 0, footer: 0 });
+
+  useEffect(() => {
+    const update = () => {
+      setOffsets({
+        header: headerRef.current?.offsetHeight || 0,
+        footer: footerRef.current?.offsetHeight || 0,
+      });
+    };
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
+
   return (
     <>
-      <Sidebar />
-      <div className={`dashboard-main ${isOpen ? 'ml-56' : 'ml-20'} min-h-screen flex flex-col`}>
-        <Header />
-        <div className="flex-1">{children}</div>
-        <Footer />
+      <Sidebar headerHeight={offsets.header} footerHeight={offsets.footer} />
+      <div
+        className={`dashboard-main ${isOpen ? 'ml-56' : 'ml-20'} min-h-screen flex flex-col`}
+        style={{ paddingTop: offsets.header, paddingBottom: offsets.footer }}
+      >
+        <Header ref={headerRef} />
+        <div
+          className="flex-1 overflow-y-auto"
+          style={{ minHeight: `calc(100vh - ${offsets.header + offsets.footer}px)` }}
+        >
+          {children}
+        </div>
+        <Footer ref={footerRef} />
       </div>
     </>
   );

--- a/src/components/common/Footer.jsx
+++ b/src/components/common/Footer.jsx
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { FaGithub, FaLinkedin, FaTwitter } from 'react-icons/fa';
 
-const Footer = () => (
-  <footer className="fixed bottom-0 left-0 w-full bg-dark-gray border-t border-mid-gray h-12 flex items-center justify-between px-8 z-30">
+const Footer = forwardRef((props, ref) => (
+  <footer
+    ref={ref}
+    className="fixed bottom-0 left-0 w-full bg-dark-gray border-t border-mid-gray h-12 flex items-center justify-between px-8 z-30"
+  >
     <span className="font-mono text-[12px] text-teal-300 tracking-widest select-none">
       Fedrix Vision Suite
     </span>
@@ -36,5 +39,5 @@ const Footer = () => (
       </span>
     </div>
   </footer>
-);
+));
 export default Footer;

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useState, forwardRef } from "react";
 import { motion } from "framer-motion";
 import { HiChevronDown } from "react-icons/hi";
 import { useLocation } from "react-router-dom";
@@ -10,7 +10,7 @@ import { useNavigate } from "react-router-dom";
 import HologramTitle from "./HologramTitle.jsx";
 import logo from "../../assets/fedrix.svg";
 
-const Header = () => {
+const Header = forwardRef((props, ref) => {
   const { profile, logoutProfile } = useContext(UserProfileContext);
   const location = useLocation();
 
@@ -49,6 +49,7 @@ const Header = () => {
 
   return (
     <motion.header
+      ref={ref}
       className="fixed top-0 left-0 right-0 w-full flex items-center justify-between px-8 py-4 border-b border-white/10 backdrop-blur-xl bg-white/5 z-40"
       initial={{ y: -50, opacity: 0 }}
       animate={{ y: 0, opacity: 1 }}

--- a/src/components/common/Sidebar.jsx
+++ b/src/components/common/Sidebar.jsx
@@ -1,4 +1,5 @@
 import React, { useContext } from "react";
+import PropTypes from "prop-types";
 import { NavLink } from "react-router-dom";
 import { AuthContext } from "../../context/AuthContext";
 import { UserProfileContext } from "../../context/UserProfileContext";
@@ -12,7 +13,7 @@ import {
   HiOutlineBell,
 } from "react-icons/hi";
 
-const Sidebar = () => {
+const Sidebar = ({ headerHeight = 0, footerHeight = 0 }) => {
   const { user } = useContext(AuthContext);
   const { profile } = useContext(UserProfileContext);
   const { isOpen, openSidebar, closeSidebar } = useContext(SidebarContext);
@@ -33,13 +34,11 @@ const Sidebar = () => {
     <aside
       onMouseEnter={openSidebar}
       onMouseLeave={closeSidebar}
-      className={`fixed left-0 top-20 bottom-12 bg-black border-r border-white/10 px-4 py-8 z-50 shadow-xl overflow-x-hidden transition-all duration-300 ${
+      style={{ top: headerHeight, bottom: footerHeight }}
+      className={`fixed left-0 bg-black border-r border-white/10 px-4 py-8 z-50 shadow-xl overflow-x-hidden transition-all duration-300 ${
         isOpen ? "w-56" : "w-20"
       }`}
     >
-      <div className="text-center mb-10 whitespace-nowrap">
-        <h1 className="text-gray-300 text-xl font-bold">Fedrix Vision</h1>
-      </div>
 
       <nav className="flex flex-col space-y-4">
         {navItems
@@ -67,3 +66,8 @@ const Sidebar = () => {
 };
 
 export default Sidebar;
+
+Sidebar.propTypes = {
+  headerHeight: PropTypes.number,
+  footerHeight: PropTypes.number,
+};

--- a/src/components/dashboard/AIChatWidget.jsx
+++ b/src/components/dashboard/AIChatWidget.jsx
@@ -93,7 +93,7 @@ const AIChatWidget = ({ className }) => {
 
   return (
     <div
-      className={`glassy-tile rounded-xl shadow-2xl min-h-[420px] p-6 flex flex-col ${className || ''}
+      className={`glassy-tile rounded-xl shadow-2xl min-h-[300px] p-6 flex flex-col ${className || ''}
                     bg-gradient-to-br from-cyan-900/60 via-blue-900/30 to-cyan-800/50`}
     >
       <h3 className="text-lg font-semibold text-white/80 mb-4 pb-2 border-b border-indigo-600/30 flex items-center justify-between">

--- a/src/components/dashboard/RecentActivityFeed.jsx
+++ b/src/components/dashboard/RecentActivityFeed.jsx
@@ -284,7 +284,7 @@ const RecentActivityFeed = ({ className }) => {
 
   return (
     <div
-      className={`glassy-tile rounded-xl shadow-2xl min-h-[420px] p-6 flex flex-col ${className || ''}
+      className={`glassy-tile rounded-xl shadow-2xl min-h-[300px] p-6 flex flex-col ${className || ''}
                     bg-gradient-to-br from-teal-900/60 via-indigo-900/30 to-teal-800/50`}
     >
       <h3 className="text-lg font-semibold text-white/80 mb-4 pb-2 border-b border-blue-600/30">

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -20,28 +20,28 @@ const Dashboard = () => {
               value="12"
               description="Active"
               icon={CheckSquareIcon}
-              gradient="from-fuchsia-600/60 to-pink-800/60"
+              gradient="from-fuchsia-500/40 to-pink-700/40"
             />
             <StatCard
               title="Clients"
               value="8"
               description="Engaged"
               icon={UsersIcon}
-              gradient="from-violet-600/60 to-indigo-800/60"
+              gradient="from-violet-500/40 to-indigo-700/40"
             />
             <StatCard
               title="Revenue"
               value="$24k"
               description="This Month"
               icon={DollarSignIcon}
-              gradient="from-emerald-600/60 to-teal-800/60"
+              gradient="from-emerald-500/40 to-teal-700/40"
             />
             <StatCard
               title="Rating"
               value="4.9"
               description="Average"
               icon={StarIcon}
-              gradient="from-orange-600/60 to-amber-800/60"
+              gradient="from-orange-500/40 to-amber-700/40"
             />
           </div>
 


### PR DESCRIPTION
## Summary
- make sidebar use dynamic positions and remove static title
- convert header and footer to forwardRef
- implement dynamic padding in `DashboardLayout`
- lighten stat card colors and shorten widget heights
- add routes for analytics, social calendar, API keys, tools, and app settings

## Testing
- `npm run lint` *(fails: eslint-plugin-react missing)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f07b9f1348333b46606105520efc2