### PR TITLE
Fix role retrieval in auth context

### DIFF
--- a/src/components/auth/ProtectedRoute.js
+++ b/src/components/auth/ProtectedRoute.js
@@ -4,15 +4,18 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Navigate } from "react-router-dom";
 import { useAuth } from "../../context/AuthContext";
+import { useUserProfile } from "../../context/UserProfileContext";
 
 const ProtectedRoute = ({ children, requiredRole }) => {
   const { currentUser } = useAuth();
+  const { profile } = useUserProfile();
   if (!currentUser) return <Navigate to="/login" replace />;
 
+  const role = profile?.role || currentUser.role;
   if (
     requiredRole &&
-    currentUser.role !== requiredRole &&
-    !(currentUser.role === "super_admin" && requiredRole === "admin")
+    role !== requiredRole &&
+    !(role === "super_admin" && requiredRole === "admin")
   ) {
     return <Navigate to="/unauthorized" replace />;
   }


### PR DESCRIPTION
## Summary
- ensure user roles are loaded from `user_profiles`
- use profile role in ProtectedRoute

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run lint --silent` *(fails: ESLint plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_685f0a8cb1a88333b160111fdb416702