### PR TITLE
Fix Header forwardRef closing parenthesis

### DIFF
--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -96,6 +96,6 @@ const Header = forwardRef((props, ref) => {
       </div>
     </motion.header>
   );
-};
+});
 
 export default Header;


### PR DESCRIPTION
## Summary
- close forwardRef component in Header.jsx to fix syntax error

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run lint` *(fails: missing eslint-plugin-react)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f0cf928648333a28c94bec5256bad