### PR TITLE
Fix missing display name for Header

### DIFF
--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -96,6 +96,8 @@ const Header = forwardRef((props, ref) => {
       </div>
     </motion.header>
   );
-};
+});
+
+Header.displayName = 'Header';
 
 export default Header;


### PR DESCRIPTION
## Summary
- set `Header.displayName` to satisfy ESLint

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run lint` *(fails: missing eslint-plugin-react)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f0cf928648333a28c94bec5256bad