### PR TITLE
Fix login redirect

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ import {
   RouterProvider,
   Navigate,
 } from "react-router-dom";
-import Login from "./pages/Login";
+import LoginPage from "./pages/auth/LoginPage.jsx";
 import Dashboard from "./pages/Dashboard.jsx";
 import KanbanBoard from "./components/kanban/KanbanBoard.jsx";
 import Calendar from "./components/calendar/Calendar.jsx";
@@ -44,7 +44,7 @@ const App = () => {
           },
           {
             path: '/login',
-            element: <Login />,
+            element: <LoginPage />,
           },
           {
             path: '/dashboard/profile',

--- a/src/components/common/Header.jsx
+++ b/src/components/common/Header.jsx
@@ -96,6 +96,8 @@ const Header = forwardRef((props, ref) => {
       </div>
     </motion.header>
   );
-};
+});
+
+Header.displayName = 'Header';
 
 export default Header;


### PR DESCRIPTION
## Summary
- use new `LoginPage` component for `/login`

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm run lint` *(fails: missing eslint-plugin-react)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f0cf928648333a28c94bec5256bad