### PR TITLE
Fix missing display name and add install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ has likely not been created in your Supabase project. Apply the migration using
 psql < supabase/create_reminders_table.sql
 ```
 
+If the development server fails with errors such as `Module not found: Can't resolve 'react-big-calendar'`, ensure all dependencies are installed by running:
+
+```bash
+npm install
+```
+
+
 ### 🚀 Development
 
 #### Web

--- a/src/components/common/Footer.jsx
+++ b/src/components/common/Footer.jsx
@@ -38,6 +38,7 @@ const Footer = forwardRef((props, ref) => (
         v1.0.0 | Fedrix MediaLab
       </span>
     </div>
-  </footer>
+ </footer>
 ));
+Footer.displayName = 'Footer';
 export default Footer;


### PR DESCRIPTION
## Summary
- add `Footer.displayName` to satisfy ESLint
- document running `npm install` if modules are missing

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: eslint-plugin-react not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f1792c9508333bae94bb862594b3a